### PR TITLE
Automatically enforce and normalize image filenames

### DIFF
--- a/.github/workflows/check-pr-filenames.yml
+++ b/.github/workflows/check-pr-filenames.yml
@@ -1,0 +1,94 @@
+name: Check image filename format
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  check-filenames:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check added/renamed image filenames
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const path = require('path');
+
+            const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp)$/i;
+            const MARKER = '<!-- filename-check-bot -->';
+
+            function normalizeBase(base) {
+              const tokens = base.split(/[\s_-]+/).filter(Boolean);
+              const normalized = tokens.map(t =>
+                /^[a-z]+$/.test(t) ? t[0].toUpperCase() + t.slice(1) : t
+              );
+              return normalized.join('_');
+            }
+
+            function expectedPath(filename) {
+              const ext = path.extname(filename);
+              const dir = path.dirname(filename);
+              const base = path.basename(filename, ext);
+              const normalized = normalizeBase(base) + ext.toLowerCase();
+              return dir === '.' ? normalized : `${dir}/${normalized}`;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const violations = [];
+            for (const f of files) {
+              if (!['added', 'renamed'].includes(f.status)) continue;
+              if (!IMAGE_EXT.test(f.filename)) continue;
+              const dir = path.dirname(f.filename);
+              if (dir === '.' || dir.startsWith('.github')) continue;
+
+              const expected = expectedPath(f.filename);
+              if (expected !== f.filename) {
+                violations.push({ actual: f.filename, expected });
+              }
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find(c => c.body.includes(MARKER));
+
+            if (violations.length > 0) {
+              const lines = violations.map(v => `- \`${v.actual}\` → \`${v.expected}\``);
+              const body = `${MARKER}\n### Some image filenames don't match the expected format\n\nExpected format: \`Name_Name_Book_Book.ext\` (words separated by underscores, each word capitalized).\n\nPlease rename:\n\n${lines.join('\n')}\n`;
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body,
+                });
+              }
+
+              core.setFailed(`${violations.length} filename(s) don't match the expected format.`);
+            } else if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: `${MARKER}\n### All image filenames now match the expected format.\n`,
+              });
+            }

--- a/.github/workflows/normalize-filenames.yml
+++ b/.github/workflows/normalize-filenames.yml
@@ -1,0 +1,90 @@
+name: Normalize image filenames
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.jpeg'
+      - '**/*.gif'
+      - '**/*.webp'
+      - '**/*.bmp'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  normalize:
+    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip normalize]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rename non-conforming image files
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+          const path = require('path');
+
+          const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp)$/i;
+          const EXCLUDED_DIRS = new Set(['.git', '.github', 'node_modules']);
+
+          function normalizeBase(base) {
+            const tokens = base.split(/[\s_-]+/).filter(Boolean);
+            const normalized = tokens.map(t =>
+              /^[a-z]+$/.test(t) ? t[0].toUpperCase() + t.slice(1) : t
+            );
+            return normalized.join('_');
+          }
+
+          const topLevel = fs.readdirSync('.', { withFileTypes: true })
+            .filter(e => e.isDirectory() && !e.name.startsWith('.') && !EXCLUDED_DIRS.has(e.name));
+
+          const renamed = [];
+          for (const dirEntry of topLevel) {
+            const dir = dirEntry.name;
+            const entries = fs.readdirSync(dir, { withFileTypes: true });
+            for (const entry of entries) {
+              if (!entry.isFile()) continue;
+              if (!IMAGE_EXT.test(entry.name)) continue;
+
+              const ext = path.extname(entry.name);
+              const base = path.basename(entry.name, ext);
+              const normalizedName = normalizeBase(base) + ext.toLowerCase();
+
+              if (normalizedName === entry.name) continue;
+
+              const oldPath = path.join(dir, entry.name);
+              const newPath = path.join(dir, normalizedName);
+
+              if (fs.existsSync(newPath)) {
+                console.warn(`Skipping ${oldPath}: target ${newPath} already exists`);
+                continue;
+              }
+
+              fs.renameSync(oldPath, newPath);
+              renamed.push(`${oldPath} -> ${newPath}`);
+            }
+          }
+
+          if (renamed.length > 0) {
+            console.log('Renamed files:');
+            renamed.forEach(r => console.log(`  ${r}`));
+          } else {
+            console.log('No files needed renaming.');
+          }
+          EOF
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit."
+          else
+            git commit -m "chore: normalize image filenames [skip normalize]"
+            git push
+          fi


### PR DESCRIPTION
### Summary
- Adds `check-pr-filenames.yml`: on pull requests, flags any added/renamed image whose filename doesn't match the `Name_Name_Book_Book.ext` convention (words separated by underscores, each capitalized). Fails the check and posts an automatic comment with the expected filename.
- Adds `normalize-filenames.yml`: on push to `master` (and via manual `workflow_dispatch`), scans all top-level folders and renames non-conforming image files in place, committing the fix directly. This also cleans up the existing backlog of inconsistently named files, and catches anything merged despite a failing PR check.
